### PR TITLE
[#61] Made ``_stop_tmp_fact`` a public method.

### DIFF
--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -609,7 +609,7 @@ class BaseFactManager(BaseManager):
             self.store.logger.debug(_("New temporary fact started."))
         return fact
 
-    def _stop_tmp_fact(self):
+    def stop_tmp_fact(self):
         """
         Stop current 'ongoing fact'.
 

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -273,7 +273,7 @@ class TestFactManager:
     def test_stop_tmp_fact(self, basestore, base_config, tmp_fact, fact, mocker):
         """Make sure we can stop an 'ongoing fact' and that it will have an end set."""
         basestore.facts._add = mocker.MagicMock()
-        basestore.facts._stop_tmp_fact()
+        basestore.facts.stop_tmp_fact()
         assert basestore.facts._add.called
         fact_to_be_added = basestore.facts._add.call_args[0][0]
         assert fact_to_be_added.end
@@ -284,4 +284,4 @@ class TestFactManager:
     def test_stop_tmp_fact_non_existing(self, basestore):
         """Make sure that trying to call stop when there is no 'ongoing fact' raises error."""
         with pytest.raises(ValueError):
-            basestore.facts._stop_tmp_fact()
+            basestore.facts.stop_tmp_fact()


### PR DESCRIPTION
This PR turns our method for stoping 'ongoing facts' into a public API call.

Closes #61 