### PR TITLE
[#60] Add ``get_tmp_fact`` fact-manager method.

### DIFF
--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -497,6 +497,7 @@ class BaseFactManager(BaseManager):
             * This public function only provides some sanity checks and normalization. The actual
             backend query is handled by ``_get_all``.
             * ``search_term`` should be prefixable with ``not`` in order to invert matching.
+            * This does only return proper facts and does not include any existing 'ongoing fact'.
         """
 
         if start is not None:
@@ -559,6 +560,9 @@ class BaseFactManager(BaseManager):
 
         Returns:
             list: List of ``Fact`` instances.
+
+        Note:
+            * This does only return proper facts and does not include any existing 'ongoing fact'.
         """
         today = datetime.date.today()
         return self.get_all(
@@ -629,3 +633,20 @@ class BaseFactManager(BaseManager):
             self.store.logger.debug(message)
             raise ValueError(message)
         return result
+
+    def get_tmp_fact(self):
+        """
+        Provide a way to retrieve any existing 'ongoing fact'.
+
+        Returns:
+            hamsterlib.Fact: An instance representing our current 'ongoing fact'.capitalize
+
+        Raises:
+            KeyError: If no ongoing fact is present.
+        """
+        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        if not fact:
+            message = _("Tried to retrieve an 'ongoing fact' when there is none present.")
+            self.store.logger.debug(message)
+            raise KeyError(message)
+        return fact

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -284,3 +284,13 @@ class TestFactManager:
         """Make sure that trying to call stop when there is no 'ongoing fact' raises error."""
         with pytest.raises(ValueError):
             basestore.facts.stop_tmp_fact()
+
+    def test_get_tmp_fact(self, basestore, tmp_fact, fact):
+        """Make sure we return the 'ongoing_fact'."""
+        fact = basestore.facts.get_tmp_fact()
+        assert fact == fact
+
+    def test_get_tmp_fact_without_ongoing_fact(self, basestore):
+        """Make sure that we raise a KeyError if ther is no 'ongoing fact'."""
+        with pytest.raises(KeyError):
+            basestore.facts.get_tmp_fact()


### PR DESCRIPTION
This PR adds a ``get_tmp_fact`` method to our fact-manager class.
This allows clients to easily retrieve the ongoing fact if there is one. We raises an ``KeyError`` otherwise.

Closes: #60