### PR TITLE
[#59] Add ``cancel_tmp_fact`` fact-manager method.

### DIFF
--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -650,3 +650,21 @@ class BaseFactManager(BaseManager):
             self.store.logger.debug(message)
             raise KeyError(message)
         return fact
+
+    def cancel_tmp_fact(self):
+        """
+        Provide a way to stop an 'ongoing fact' without saving it in the backend.
+
+        Returns:
+            None: If everything worked as expected.
+
+        Raises:
+            KeyError: If no ongoing fact is present.
+        """
+        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        if not fact:
+            message = _("Trying to stop a non existing ongoing fact.")
+            self.store.logger.debug(message)
+            raise KeyError(message)
+        os.remove(helpers._get_tmp_fact_path(self.store.config))
+        self.store.logger.debug(_("Temporary fact stoped."))

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -294,3 +294,14 @@ class TestFactManager:
         """Make sure that we raise a KeyError if ther is no 'ongoing fact'."""
         with pytest.raises(KeyError):
             basestore.facts.get_tmp_fact()
+
+    def test_cancel_tmp_fact(self, basestore, tmp_fact, fact):
+        """Make sure we return the 'ongoing_fact'."""
+        result = basestore.facts.cancel_tmp_fact()
+        assert result is None
+        assert os.path.exists(helpers._get_tmp_fact_path(basestore.config)) is False
+
+    def test_cancel_tmp_fact_without_ongoing_fact(self, basestore):
+        """Make sure that we raise a KeyError if ther is no 'ongoing fact'."""
+        with pytest.raises(KeyError):
+            basestore.facts.cancel_tmp_fact()


### PR DESCRIPTION
This PR provides a ``cancel_tmp_fact`` method to our fact-manager class.
This allows clients to stop an ongoing fact without storing it to the backend.
Closes: #59