### PR TITLE
[75] Treshold for ongoing facts

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,6 +15,7 @@ pairs::
         'store': 'sqlalchemy'; refer to ``hamsterlib.lib.REGISTERED_BACKENDS``
         'db_path': ``sqlalchemy db path``,
         'tmpfile_name': filename; under which any 'ongoing fact' will be saved
+        'fact_min_delta': integer; Amount of seconds under which fact creation will be prohibited.
 
 ``hamsterlib.HamsterControl`` initializes the store and provides a general logger.
 Besides that ``HamsterControl.categories``, ``HamsterControl.activities`` and 

--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -401,14 +401,29 @@ class BaseFactManager(BaseManager):
         """
         Save a Fact to our selected backend.
 
+        Unlike the private ``_add`` and ``_update`` methods, ``save`` enforces that
+        the config given ``fact_min_delta`` is enforced.
+
         Args:
             fact (hamsterlib.Fact): Fact to be saved. Needs to be complete otherwise
             this will fail.
 
         Returns:
             hamsterlib.Fact: Saved Fact.
+
+        Raises:
+            ValueError: If ``fact.delta`` is smaller than ``self.store.config['fact_min_delta']``-
         """
         self.store.logger.debug(_("Fact: '{}' has been recieved.".format(fact)))
+
+        fact_min_delta = datetime.timedelta(seconds=int(self.store.config['fact_min_delta']))
+        if fact.delta and (fact.delta < fact_min_delta):
+            message = _(
+                "The passed facts delta is shorter than the mandatory value of {} seconds"
+                " specified in your config.".format(fact_min_delta)
+            )
+            self.store.logger.error(message)
+            raise ValueError(message)
 
         if fact.pk or fact.pk == 0:
             result = self._update(fact)

--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -673,7 +673,7 @@ class BaseFactManager(BaseManager):
         fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
         if fact:
             fact.end = datetime.datetime.now()
-            result = self._add(fact)
+            result = self.save(fact)
             os.remove(helpers._get_tmp_fact_path(self.store.config))
             self.store.logger.debug(_("Temporary fact stoped."))
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def base_config(tmpdir):
         'day_start': datetime.time(hour=5, minute=30, second=0),
         'db_path': 'sqlite:///:memory:',
         'tmpfile_name': 'hamsterlib.fact',
+        'fact_min_delta': 60,
     }
 
 

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -167,6 +167,13 @@ class TestFactManager:
         basestore.facts.save(fact)
         assert basestore.facts._start_tmp_fact.called
 
+    def test_save_to_brief_fact(self, basestore, fact):
+        """Ensure that a fact with to small delta raises an exception."""
+        delta = datetime.timedelta(seconds=(basestore.config['fact_min_delta'] - 1))
+        fact.end = fact.start + delta
+        with pytest.raises(ValueError):
+            basestore.facts.save(fact)
+
     def test_add(self, basestore, fact):
         with pytest.raises(NotImplementedError):
             basestore.facts._add(fact)


### PR DESCRIPTION
This PR introduces the notion of a *minimum delta* for facts.
For this purpose a new config-key ``fact_min_delta`` has been introduced. Facts with a delta smaller than this are not to be stored by the backend. Instead we raise a ``ValueError``.
This is implemented by adjusting the ``save`` method of our fact manager.

Closes: #75