### PR TITLE
[50] Add ical export capabilities.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.10.0
 ------
+* Add ``ical`` export facilities. Brand new writer using the ``icalendar`` library.
 * Switch to `semantic versioning <http://semver.org>`_
 * Added GPL3 boilerplate
 

--- a/hamsterlib/backends/sqlalchemy/objects.py
+++ b/hamsterlib/backends/sqlalchemy/objects.py
@@ -48,7 +48,6 @@ from sqlalchemy import (Boolean, Column, DateTime, ForeignKey, Integer,
                         MetaData, Table, Unicode, UniqueConstraint)
 from sqlalchemy.orm import mapper, relationship
 
-
 DEFAULT_STRING_LENGTH = 254
 
 

--- a/hamsterlib/objects.py
+++ b/hamsterlib/objects.py
@@ -27,7 +27,6 @@ from collections import namedtuple
 from future.utils import python_2_unicode_compatible
 from six import text_type
 
-
 CategoryTuple = namedtuple('CategoryTuple', ('pk', 'name'))
 ActivityTuple = namedtuple('ActivityTuple', ('pk', 'name', 'category', 'deleted'))
 FactTuple = namedtuple('FactTuple', ('pk', 'activity', 'start', 'end', 'description', 'tags'))

--- a/hamsterlib/reports.py
+++ b/hamsterlib/reports.py
@@ -30,12 +30,13 @@ of ``FactTuples`` as arguments.
 from __future__ import unicode_literals
 
 import csv
+import datetime
 import sys
 from collections import namedtuple
 
 from future.utils import python_2_unicode_compatible
+from icalendar import Calendar, Event
 from six import text_type
-
 
 FactTuple = namedtuple('FactTuple', ('start', 'end', 'activity', 'category',
     'description', 'duration'))
@@ -62,6 +63,10 @@ class ReportWriter(object):
         # instances. This clearly conflics with any generic open() that provides
         # transparent text input/output and would take care of the encoding
         # instead.
+
+        # [FIXME]
+        # If it turns out that this is specific to csv handling we may move it
+        # there and use a simpler default behaviour for our base method.
         if sys.version_info < (3,):
             self.file = open(path, 'wb')
         else:
@@ -80,6 +85,74 @@ class ReportWriter(object):
         for fact in facts:
             self._write_fact(self._fact_to_tuple(fact))
         self._close()
+
+    def _fact_to_tuple(self, fact):
+        """
+        Convert a ``Fact`` to its normalized tuple.
+
+        This is where all type conversion for ``Fact`` attributes to strings as well
+        as any normalization happens.
+
+        Note:
+            Because different writers may require different types, we need to so this
+            individualy.
+
+        Args:
+            fact (hamsterlib.Fact): Fact to be converted.
+
+        Returns:
+            FactTuple: Tuple representing the original ``Fact``.
+        """
+        raise NotImplementedError
+
+    def _write_fact(self, fact):
+        """
+        Represent one ``Fact`` in the output file.
+
+        What this means exactly depends on the format and kind of output.
+        At this point all type conversions and normalization have already been done.
+
+        Args:
+            fact (FactTuple): The individual fact to be written.
+
+        Returns:
+            None
+        """
+        raise NotImplementedError
+
+    def _close(self):
+        """Default teardown method."""
+        self.file.close()
+
+
+@python_2_unicode_compatible
+class TSVWriter(ReportWriter):
+    def __init__(self, path):
+        """
+        Initialize a new instance.
+
+        Besides our default behaviour we create a localized heading.
+        Also, we need to make sure that our heading is UTF-8 encoded on python 2!
+        In that case ``self.file`` will be openend in binary mode and ready to accept
+        those encoded headings.
+        """
+        super(TSVWriter, self).__init__(path)
+        self.csv_writer = csv.writer(self.file, dialect='excel-tab')
+        headers = (
+            _("start time"),
+            _("end time"),
+            _("activity"),
+            _("category"),
+            _("description"),
+            _("duration minutes"),
+        )
+        results = []
+        for h in headers:
+            data = text_type(h)
+            if sys.version_info < (3, 0):
+                data = data.encode('utf-8')
+            results.append(data)
+        self.csv_writer.writerow(results)
 
     def _fact_to_tuple(self, fact):
         """
@@ -111,47 +184,13 @@ class ReportWriter(object):
             description=description,
         )
 
-    def _write_fact(self, fact):
-        """
-        Represent one ``Fact`` in the output file.
-
-        What this means exactly depends on the format and kind of output.
-        At this point all type conversions and normalization have already been done.
-
-        Args:
-            fact (FactTuple): The individual fact to be written.
-
-        Returns:
-            None
-        """
-        raise NotImplementedError
-
-    def _close(self):
-        self.file.close()
-
-
-@python_2_unicode_compatible
-class TSVWriter(ReportWriter):
-    def __init__(self, path):
-        super(TSVWriter, self).__init__(path)
-        self.csv_writer = csv.writer(self.file, dialect='excel-tab')
-        headers = (
-            _("start time"),
-            _("end time"),
-            _("activity"),
-            _("category"),
-            _("description"),
-            _("duration minutes"),
-        )
-        results = []
-        for h in headers:
-            data = text_type(h)
-            if sys.version_info < (3, 0):
-                data = data.encode('utf-8')
-            results.append(data)
-        self.csv_writer.writerow(results)
-
     def _write_fact(self, fact_tuple):
+        """
+        Write a single fact.
+
+        On python 2 we need to make sure we encode our data accordingly so we can feed it to our
+        file object which in this case needs to be opened in binary mode.
+        """
         results = []
         for value in fact_tuple:
             data = text_type(value)
@@ -159,3 +198,80 @@ class TSVWriter(ReportWriter):
                 data = data.encode('utf-8')
             results.append(data)
         self.csv_writer.writerow(results)
+
+
+@python_2_unicode_compatible
+class ICALWriter(ReportWriter):
+    """A simple ical writer for fact export."""
+    def __init__(self, path, datetime_format="%Y-%m-%d %H:%M:%S"):
+        """
+        Initiate new instance and open an output file like object.
+
+        Args:
+            path: File like object to be opend. This is where all output will be directed to.
+            datetime_format (str): String specifying how datetime information is to be
+                rendered in the output.
+        """
+        self.datetime_format = datetime_format
+        self.file = open(path, 'wb')
+        self.calendar = Calendar()
+
+    def _fact_to_tuple(self, fact):
+        """
+        Convert a ``Fact`` to its normalized tuple.
+
+        This is where all type conversion for ``Fact`` attributes to strings as well
+        as any normalization happens.
+
+        Note:
+            Because different writers may require different types, we need to so this
+            individualy.
+
+        Args:
+            fact (hamsterlib.Fact): Fact to be converted.
+
+        Returns:
+            FactTuple: Tuple representing the original ``Fact``.
+        """
+        # Fields that may have ``None`` value will be represented by ''
+        if fact.category:
+            category = fact.category.name
+        else:
+            category = ''
+
+        description = fact.description or ''
+
+        return FactTuple(
+            start=fact.start,
+            end=fact.end,
+            activity=text_type(fact.activity.name),
+            duration=None,
+            category=text_type(category),
+            description=text_type(description),
+        )
+
+    def _write_fact(self, fact_tuple):
+        """
+        Write a singular fact to our report.
+
+        Note:
+            * ``dtent`` is non-inclusive according to Page 54 of RFC 5545
+
+        Returns:
+            None: If everything worked out alright.
+        """
+        # [FIXME]
+        # It apears that date/time requirements for VEVENT have changed between
+        # RFCs. 5545 now seems to require a 'dstamp' and a 'uid'!
+        event = Event()
+        event.add('dtstart', fact_tuple.start)
+        event.add('dtend', fact_tuple.end + datetime.timedelta(seconds=1))
+        event.add('categories', fact_tuple.category)
+        event.add('summary', fact_tuple.activity)
+        event.add('description', fact_tuple.description)
+        self.calendar.add_component(event)
+
+    def _close(self):
+        """Custom close method to make sure the calendar is actually writen do disk."""
+        self.file.write(self.calendar.to_ical())
+        return super(ICALWriter, self)._close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ source = hamsterlib
 
 [isort]
 not_skip = __init__.py
-known_third_party = faker,factory, faker, freezegun, future, hamsterlib, past, pytest, pytest_factoryboy,
+known_third_party = faker,factory, faker, freezegun, future, hamsterlib, icalendar, past, pytest, pytest_factoryboy,
 	six, sqlalchemy, fauxfactory
 
 [pytest]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
-    'future', 'sqlalchemy',
+    'future',
+    'sqlalchemy',
+    'icalendar',
 ]
 
 test_requirements = [

--- a/tests/hamsterlib/conftest.py
+++ b/tests/hamsterlib/conftest.py
@@ -111,11 +111,19 @@ def fact():
 
 @pytest.fixture
 def list_of_facts(fact_factory):
-    """Provide a factory that returns a list with given amount of Fact instances."""
+    """
+    Provide a factory that returns a list with given amount of Fact instances.
+
+    The key point here is that these fact *do not overlap*!
+    """
     def get_list_of_facts(number_of_facts):
         facts = []
+        old_start = datetime.datetime.now()
+        offset = datetime.timedelta(hours=4)
         for i in range(number_of_facts):
-            facts.append(fact_factory())
+            start = old_start + offset
+            facts.append(fact_factory(start=start))
+            old_start = start
         return facts
     return get_list_of_facts
 

--- a/tests/hamsterlib/factories.py
+++ b/tests/hamsterlib/factories.py
@@ -35,6 +35,11 @@ class ActivityFactory(factory.Factory):
 
 @python_2_unicode_compatible
 class FactFactory(factory.Factory):
+    """
+    Create a new fact instance.
+
+    Instances have a duration of 3 hours.
+    """
     pk = None
     activity = factory.SubFactory(ActivityFactory)
     start = faker.Faker().date_time()


### PR DESCRIPTION
iCal export is provided via the ``icalendar`` library.
In the process it became clear that the BaseWriters ``fact_to_tuple``
method is needed on an individual writer by writer basis as its
particular type conversions are specific to its writer. As a consequence
the basewriter method now raises ``NotImplementedError``. Tests have
been adjusted accordingly.

Closes: #50