### PR TITLE
[49] Add XMLWriter class.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,5 +10,9 @@ Development Lead
 Contributors
 ------------
 
-* [tbaugis](https://github.com/tbaugis): `parse_time_info` from [hamster-cli](
-  https://github.com/projecthamster/hamster/blob/master/src/hamster-cli)
+Code taken from 'legacy hamster'
+--------------------------------
+
+* `tbaugis <https://github.com/tbaugis>`_:
+  * ``parse_time_info`` from `hamster-cli <https://github.com/projecthamster/hamster/blob/master/src/hamster-cli>`_
+  * ``XMLWriter`` from `hamster <https://github.com/projecthamster/hamster/blame/master/src/hamster/reports.py>`_


### PR DESCRIPTION
This PR introduces the XMLWriter class suitable for fact export as xmldata.
We mainly reused the XMLWriter from legacy hamster  with just minor changes.
Its also worth noting that w sticked to most of the sub-optimal naming for increated compability for now.

Closes: #49