### PR TITLE
[97] Made 'get_tmp_file_path' a BaseStore attribute.

### DIFF
--- a/hamsterlib/helpers.py
+++ b/hamsterlib/helpers.py
@@ -28,7 +28,6 @@ consistent and tested behaviour.
 
 
 import datetime
-import os.path
 import pickle
 import re
 from collections import namedtuple
@@ -329,8 +328,3 @@ def _load_tmp_fact(filepath):
                     content=fact, type=type(fact))
             ))
     return fact
-
-
-def _get_tmp_fact_path(config):
-    """Convinience function to assemble the tmpfile_path from config settings."""
-    return os.path.join(config['work_dir'], config['tmpfile_name'])

--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -44,7 +44,7 @@ from hamsterlib import objects
 @python_2_unicode_compatible
 class BaseStore(object):
     """
-    A controller store provides unified interfaces to interact with our stored entities.
+    A controlers store provides unified interfaces to interact with our stored entities.
 
     ``self.logger`` provides a dedicated logger instance for any storage related logging.
     If you want to make use of it, just setup and attach your handlers and you are ready to go.
@@ -67,6 +67,19 @@ class BaseStore(object):
         we shut down gracefully.
         """
         raise NotImplementedError
+
+    def _get_tmp_fact_path(self):
+        """
+        Helper method to return the tmpfile path.
+
+        Under naive circumstances this just returns 'tmpfile_path' from config.
+        However, if we want to implement some custom workdir logic, we just plug it here
+        without further need to amend any library code that utilizes it.
+
+        Return:
+            str: Absolute path under which the tmpfile is to be stored.
+        """
+        return self.config['tmpfile_path']
 
 
 @python_2_unicode_compatible
@@ -717,7 +730,7 @@ class BaseFactManager(BaseManager):
         """
         self.store.logger.debug(_("Trying to get 'ongoing fact'."))
 
-        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        fact = helpers._load_tmp_fact(self.store._get_tmp_fact_path())
         if not fact:
             message = _("Tried to retrieve an 'ongoing fact' when there is none present.")
             self.store.logger.debug(message)
@@ -740,10 +753,10 @@ class BaseFactManager(BaseManager):
         # it up before canceling. which would result in two retrievals.
         self.store.logger.debug(_("Trying to cancel 'ongoing fact'."))
 
-        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        fact = helpers._load_tmp_fact(self.store._get_tmp_fact_path())
         if not fact:
             message = _("Trying to stop a non existing ongoing fact.")
             self.store.logger.debug(message)
             raise KeyError(message)
-        os.remove(helpers._get_tmp_fact_path(self.store.config))
+        os.remove(self.store._get_tmp_fact_path())
         self.store.logger.debug(_("Temporary fact stoped."))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import datetime
+import os.path
 
 import fauxfactory
 import pytest
@@ -8,11 +9,10 @@ import pytest
 def base_config(tmpdir):
     """Provide a generic baseline configuration."""
     return {
-        'work_dir': tmpdir.mkdir('hamsterlib').strpath,
         'store': 'sqlalchemy',
         'day_start': datetime.time(hour=5, minute=30, second=0),
         'db_path': 'sqlite:///:memory:',
-        'tmpfile_name': 'hamsterlib.fact',
+        'tmpfile_path': os.path.join(tmpdir.mkdir('tmpfile').strpath, 'hamsterlib.fact'),
         'fact_min_delta': 60,
     }
 

--- a/tests/hamsterlib/conftest.py
+++ b/tests/hamsterlib/conftest.py
@@ -7,7 +7,6 @@ import pickle
 
 import faker as faker_
 import pytest
-from hamsterlib import helpers
 from hamsterlib.lib import HamsterControl
 from pytest_factoryboy import register
 
@@ -41,7 +40,7 @@ def convert_time_to_datetime(time_string):
 def tmp_fact(base_config, fact):
     """Provide an existing 'ongoing fact'."""
     fact.end = None
-    with open(helpers._get_tmp_fact_path(base_config), 'wb') as fobj:
+    with open(base_config['tmpfile_path'], 'wb') as fobj:
         pickle.dump(fact, fobj)
     return fact
 

--- a/tests/hamsterlib/test_helpers.py
+++ b/tests/hamsterlib/test_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import datetime
-import os.path
 import pickle
 
 import pytest
@@ -221,25 +220,13 @@ class TestLoadTmpFact(object):
 
     def test_file_instance_invalid(self, base_config):
         """Make sure we throw an error if the instance picked in the file is no ``Fact``."""
-        with open(helpers._get_tmp_fact_path(base_config), 'wb') as fobj:
+        with open(base_config['tmpfile_path'], 'wb') as fobj:
             pickle.dump('foobar', fobj)
         with pytest.raises(TypeError):
-            helpers._load_tmp_fact(helpers._get_tmp_fact_path(base_config))
+            helpers._load_tmp_fact(base_config['tmpfile_path'])
 
     def test_valid(self, base_config, tmp_fact, fact):
         """Make sure that we return the stored 'ongoing fact' as expected."""
         fact.end = None
-        result = helpers._load_tmp_fact(helpers._get_tmp_fact_path(base_config))
+        result = helpers._load_tmp_fact(base_config['tmpfile_path'])
         assert result == fact
-
-
-class TestGetTmpFactPath(object):
-    """Test regarding composition of the tmpfile path."""
-    def test_valid(self, base_config):
-        """Make sure the returned path matches our expectation."""
-        # [TODO]
-        # Would be nice to avoid the code replication. However, we can not
-        # simply use fixed strings as path composition is platform dependent.
-        expectation = os.path.join(base_config['work_dir'], base_config['tmpfile_name'])
-        result = helpers._get_tmp_fact_path(base_config)
-        assert result == expectation

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -7,7 +7,7 @@ import pickle
 
 import pytest
 from freezegun import freeze_time
-from hamsterlib import Fact, helpers
+from hamsterlib import Fact
 from hamsterlib.storage import BaseStore
 
 
@@ -26,6 +26,13 @@ class TestBaseStore():
     def test_cleanup(self, basestore):
         with pytest.raises(NotImplementedError):
             basestore.cleanup()
+
+    def test_get_tmp_fact_path(self, basestore):
+        """Make sure the returned path matches our expectation."""
+        # [TODO]
+        # Would be nice to avoid the code replication. However, we can not
+        # simply use fixed strings as path composition is platform dependent.
+        assert basestore._get_tmp_fact_path() == basestore.config['tmpfile_path']
 
 
 class TestCategoryManager():
@@ -260,7 +267,7 @@ class TestFactManager:
         """Make sure that a valid new fact creates persistent file with proper content."""
         fact.end = None
         basestore.facts._start_tmp_fact(fact)
-        with open(helpers._get_tmp_fact_path(basestore.config), 'rb') as fobj:
+        with open(basestore._get_tmp_fact_path(), 'rb') as fobj:
             new_fact = pickle.load(fobj)
             assert isinstance(new_fact, Fact)
             assert new_fact == fact
@@ -285,7 +292,7 @@ class TestFactManager:
         assert fact_to_be_added.end
         fact_to_be_added.end = None
         assert fact == fact_to_be_added
-        assert os.path.exists(helpers._get_tmp_fact_path(base_config)) is False
+        assert os.path.exists(basestore._get_tmp_fact_path()) is False
 
     def test_stop_tmp_fact_non_existing(self, basestore):
         """Make sure that trying to call stop when there is no 'ongoing fact' raises error."""
@@ -306,7 +313,7 @@ class TestFactManager:
         """Make sure we return the 'ongoing_fact'."""
         result = basestore.facts.cancel_tmp_fact()
         assert result is None
-        assert os.path.exists(helpers._get_tmp_fact_path(basestore.config)) is False
+        assert os.path.exists(basestore._get_tmp_fact_path()) is False
 
     def test_cancel_tmp_fact_without_ongoing_fact(self, basestore):
         """Make sure that we raise a KeyError if ther is no 'ongoing fact'."""


### PR DESCRIPTION
Instead of beeing an independend helper, our tmpfile_path retrival
function is a method of ``BaseStore`` now. This should make the API more
natural.
We also removed the obsolete ``work_dir`` config dict key. Instead our
library will ony take fully qualified paths for now. That means that
instead of ``tmpfile_name`` there is not a ``tmpfile_path`` config dict
key. It is up to the client to provide the backend with proper paths.
In order to be more flexible in future about this it is advisable to
provide ``get_*_path`` hooks where possible instead of fetching the
config value directly. This way any additional future path-generation logic
does not trigger any changes with consuming code at all.

Closes: #97