### PR TITLE
[97] Make 'get_tmp_fact_path' facts-basemanger method

### DIFF
--- a/hamsterlib/helpers.py
+++ b/hamsterlib/helpers.py
@@ -28,7 +28,6 @@ consistent and tested behaviour.
 
 
 import datetime
-import os.path
 import pickle
 import re
 from collections import namedtuple
@@ -329,8 +328,3 @@ def _load_tmp_fact(filepath):
                     content=fact, type=type(fact))
             ))
     return fact
-
-
-def _get_tmp_fact_path(config):
-    """Convinience function to assemble the tmpfile_path from config settings."""
-    return os.path.join(config['work_dir'], config['tmpfile_name'])

--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -671,13 +671,13 @@ class BaseFactManager(BaseManager):
             self.store.logger.debug(message)
             raise ValueError(message)
 
-        tmp_fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        tmp_fact = helpers._load_tmp_fact(self._get_tmp_fact_path())
         if tmp_fact:
             message = _("Trying to start with ongoing fact already present.")
             self.store.logger.debug(message)
             raise ValueError(message)
         else:
-            with open(helpers._get_tmp_fact_path(self.store.config), 'wb') as fobj:
+            with open(self._get_tmp_fact_path(), 'wb') as fobj:
                 pickle.dump(fact, fobj)
             self.store.logger.debug(_("New temporary fact started."))
         return fact
@@ -693,11 +693,11 @@ class BaseFactManager(BaseManager):
             ValueError: If there is no currently 'ongoing fact' present.
         """
         self.store.logger.debug(_("Stopping 'ongoing fact'."))
-        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        fact = helpers._load_tmp_fact(self._get_tmp_fact_path())
         if fact:
             fact.end = datetime.datetime.now()
             result = self.save(fact)
-            os.remove(helpers._get_tmp_fact_path(self.store.config))
+            os.remove(self._get_tmp_fact_path())
             self.store.logger.debug(_("Temporary fact stopped."))
         else:
             message = _("Trying to stop a non existing ongoing fact.")
@@ -717,7 +717,7 @@ class BaseFactManager(BaseManager):
         """
         self.store.logger.debug(_("Trying to get 'ongoing fact'."))
 
-        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        fact = helpers._load_tmp_fact(self._get_tmp_fact_path())
         if not fact:
             message = _("Tried to retrieve an 'ongoing fact' when there is none present.")
             self.store.logger.debug(message)
@@ -740,10 +740,14 @@ class BaseFactManager(BaseManager):
         # it up before canceling. which would result in two retrievals.
         self.store.logger.debug(_("Trying to cancel 'ongoing fact'."))
 
-        fact = helpers._load_tmp_fact(helpers._get_tmp_fact_path(self.store.config))
+        fact = helpers._load_tmp_fact(self._get_tmp_fact_path())
         if not fact:
             message = _("Trying to stop a non existing ongoing fact.")
             self.store.logger.debug(message)
             raise KeyError(message)
-        os.remove(helpers._get_tmp_fact_path(self.store.config))
+        os.remove(self._get_tmp_fact_path())
         self.store.logger.debug(_("Temporary fact stoped."))
+
+    def _get_tmp_fact_path(self):
+        """Convinience function to assemble the tmpfile_path from config settings."""
+        return self.store.config['tmpfile_path']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+# -*- encoding: utf-8 -*-
+
 import datetime
+import os.path
 
 import fauxfactory
 import pytest
@@ -8,11 +11,10 @@ import pytest
 def base_config(tmpdir):
     """Provide a generic baseline configuration."""
     return {
-        'work_dir': tmpdir.mkdir('hamsterlib').strpath,
         'store': 'sqlalchemy',
         'day_start': datetime.time(hour=5, minute=30, second=0),
         'db_path': 'sqlite:///:memory:',
-        'tmpfile_name': 'hamsterlib.fact',
+        'tmpfile_path': os.path.join(tmpdir.mkdir('tmpfact').strpath, 'hamsterlib.fact'),
         'fact_min_delta': 60,
     }
 

--- a/tests/hamsterlib/conftest.py
+++ b/tests/hamsterlib/conftest.py
@@ -7,7 +7,6 @@ import pickle
 
 import faker as faker_
 import pytest
-from hamsterlib import helpers
 from hamsterlib.lib import HamsterControl
 from pytest_factoryboy import register
 
@@ -41,7 +40,7 @@ def convert_time_to_datetime(time_string):
 def tmp_fact(base_config, fact):
     """Provide an existing 'ongoing fact'."""
     fact.end = None
-    with open(helpers._get_tmp_fact_path(base_config), 'wb') as fobj:
+    with open(base_config['tmpfile_path'], 'wb') as fobj:
         pickle.dump(fact, fobj)
     return fact
 

--- a/tests/hamsterlib/test_helpers.py
+++ b/tests/hamsterlib/test_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import datetime
-import os.path
 import pickle
 
 import pytest
@@ -221,25 +220,13 @@ class TestLoadTmpFact(object):
 
     def test_file_instance_invalid(self, base_config):
         """Make sure we throw an error if the instance picked in the file is no ``Fact``."""
-        with open(helpers._get_tmp_fact_path(base_config), 'wb') as fobj:
+        with open(base_config['tmpfile_path'], 'wb') as fobj:
             pickle.dump('foobar', fobj)
         with pytest.raises(TypeError):
-            helpers._load_tmp_fact(helpers._get_tmp_fact_path(base_config))
+            helpers._load_tmp_fact(base_config['tmpfile_path'])
 
     def test_valid(self, base_config, tmp_fact, fact):
         """Make sure that we return the stored 'ongoing fact' as expected."""
         fact.end = None
-        result = helpers._load_tmp_fact(helpers._get_tmp_fact_path(base_config))
+        result = helpers._load_tmp_fact(base_config['tmpfile_path'])
         assert result == fact
-
-
-class TestGetTmpFactPath(object):
-    """Test regarding composition of the tmpfile path."""
-    def test_valid(self, base_config):
-        """Make sure the returned path matches our expectation."""
-        # [TODO]
-        # Would be nice to avoid the code replication. However, we can not
-        # simply use fixed strings as path composition is platform dependent.
-        expectation = os.path.join(base_config['work_dir'], base_config['tmpfile_name'])
-        result = helpers._get_tmp_fact_path(base_config)
-        assert result == expectation


### PR DESCRIPTION
Also, config now uses ``tmpfile_path`` instead of ``tmpfile_name`` key.
By providing a central hook in ``basestore.facts._get_tmp_fact_path`` we
are free to enhance our logic for path generation without needing to
change the client code.

Closes: #97