### PR TITLE
[106] Add documentation on packaging and requires.txt

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 * Add ``ical`` export facilities. Brand new writer using the ``icalendar`` library.
 * Switch to `semantic versioning <http://semver.org>`_
 * Added GPL3 boilerplate
+* Provide documentation on packaging and ``requirements.txt``.
 
 0.0.3 (2016-04-08)
 -------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents:
    installation
    usage
    contributing
+   packaging
    API reference <modules>
    notes
    authors

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,8 @@
 # This file specifies all packages required for local development
+# This file is not part of our packaging specification. It is used to generate
+# a reproduceable development environment. For check out ``docs/packaging``.
+# For package-requirements refer to ``setup.py``.
 
--r ./prod.txt
 -r ./docs.txt
 -r ./test.txt
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,6 @@
 # This file specifies all packages required to build the documentation.
+# This file is not part of our packaging specification. It is used to generate
+# a reproduceable documentation building environment. For check out ``docs/packaging``.
+# For package-requirements refer to ``setup.py``.
 
-Sphinx==1.4.1
+Sphinx==1.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,0 @@
-# This file specifies all packages required for end user deployment.
-
-sqlalchemy==1.0.12

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,8 @@
 # This file is used for local testing with and without tox as well as for
 # testing on the CI servers.
-
--r ./prod.txt
+# This file is not part of our packaging specification. It is used to generate
+# a reproduceable test environment. For check out ``docs/packaging``.
+# For package-requirements refer to ``setup.py``.
 
 coverage==4.0.3
 isort==4.2.5


### PR DESCRIPTION
As there are different strategies to using ``setup.py`` and/or
``requires.txt`` it seemed helpful to provide additional documentation
on the matter.

Closes #106