### PR TITLE
[107] Refactor store related config options.

### DIFF
--- a/hamsterlib/storage.py
+++ b/hamsterlib/storage.py
@@ -54,7 +54,6 @@ class BaseStore(object):
 
     def __init__(self, config):
         self.config = config
-        self.path = config['db_path']
         self.logger = logging.getLogger('hamsterlib.storage')
         self.logger.addHandler(logging.NullHandler())
         self.categories = BaseCategoryManager(self)

--- a/tests/backends/sqlalchemy/conftest.py
+++ b/tests/backends/sqlalchemy/conftest.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import datetime
 
+import fauxfactory
 import pytest
 from hamsterlib import Activity, Category, Fact
 from hamsterlib.backends.sqlalchemy import objects
@@ -49,25 +50,110 @@ def alchemy_runner(request):
 
 
 @pytest.fixture
-# [TODO] We propably want this to autouse=True
-def alchemy_store(request, alchemy_runner, base_config):
+def alchemy_config(request, base_config):
+    """Provide a config that is suitable for sqlalchemy stores."""
+    config = base_config.copy()
+    config.update({
+        'store': 'sqlalchemy',
+        'db_engine': 'sqlite',
+        'db_path': ':memory:',
+    })
+    return config
+
+
+@pytest.fixture(params=(
+    # sqlite
+    {'db_engine': 'sqlite',
+     'db_path': ':memory:'},
+    # Non-sqlite
+    {'db_engine': 'postgres',
+     'db_host': fauxfactory.gen_ipaddr(),
+     'db_port': fauxfactory.gen_integer(),
+     'db_name': fauxfactory.gen_utf8(),
+     'db_user': fauxfactory.gen_utf8(),
+     'db_password': fauxfactory.gen_utf8()},
+    {'db_engine': 'postgres',
+     'db_host': fauxfactory.gen_ipaddr(),
+     'db_name': fauxfactory.gen_utf8(),
+     'db_user': fauxfactory.gen_utf8(),
+     'db_password': fauxfactory.gen_utf8()},
+))
+def alchemy_config_parametrized(request, alchemy_config):
+    """
+    Provide a parametrized config that is suitable for sqlalchemy stores.
+
+    We need to build our expectation dynamically if we want to use faked config values.
+    """
+    config = alchemy_config.copy()
+    config.update(request.param)
+    if request.param['db_engine'] == 'sqlite':
+        expectation = '{engine}:///{path}'.format(
+            engine=request.param['db_engine'], path=request.param['db_path'])
+    else:
+        port = request.param.get('db_port', '')
+        if port:
+            port = ':{}'.format(port)
+        expectation = '{engine}://{user}:{password}@{host}{port}/{name}'.format(
+            engine=request.param['db_engine'], user=request.param['db_user'],
+            password=request.param['db_password'], host=request.param['db_host'],
+            port=port, name=request.param['db_name'])
+    return (config, expectation)
+
+
+@pytest.fixture(params=(
+    {'db_engine': None,
+     'db_path': None},
+    # sqlite
+    {'db_engine': 'sqlite',
+     'db_path': None},
+    {'db_engine': 'sqlite',
+     'db_path': ''},
+    # Non-sqlite
+    {'db_engine': 'postgres',
+     'db_host': None,
+     'db_name': fauxfactory.gen_utf8(),
+     'db_user': fauxfactory.gen_utf8(),
+     'db_password': fauxfactory.gen_alphanumeric()},
+    {'db_engine': 'postgres',
+     'db_host': fauxfactory.gen_ipaddr(),
+     'db_name': '',
+     'db_user': fauxfactory.gen_utf8(),
+     'db_password': fauxfactory.gen_alphanumeric()},
+    {'db_engine': 'postgres',
+     'db_host': fauxfactory.gen_ipaddr(),
+     'db_name': fauxfactory.gen_utf8(),
+     'db_user': '',
+     'db_password': fauxfactory.gen_alphanumeric()},
+    {'db_engine': 'postgres',
+     'db_host': fauxfactory.gen_ipaddr(),
+     'db_name': fauxfactory.gen_utf8(),
+     'db_user': fauxfactory.gen_utf8(),
+     'db_password': ''}
+))
+def alchemy_config_missing_store_config_parametrized(request, alchemy_config):
+    """Provide an alchemy config containing invalid key/value pairs for store initialization."""
+    config = alchemy_config.copy()
+    config.update(request.param)
+    return config
+
+
+@pytest.fixture
+# [TODO] We probably want this to autouse=True
+def alchemy_store(request, alchemy_runner, alchemy_config):
     """
     Provide a SQLAlchemyStore that uses our test-session.
 
     Note:
         The engine created as part of the store.__init__() goes simply unused.
     """
-    config = base_config.copy()
-    config.update({'store': 'sqlalchemy'})
-    store = SQLAlchemyStore(config, common.Session)
-    return store
+    return SQLAlchemyStore(alchemy_config, common.Session)
 
 
 # We are sometimes tempted not using hamsterlib.objects at all. but as our tests
 # expect them as input we need them!
 
 # Instance sets
-# Convinience fixtures that provide mulitudes of certain alchemy instances.
+# Convenience fixtures that provide multitudes of certain alchemy instances.
 @pytest.fixture
 def set_of_categories(alchemy_category_factory):
     """Provide a number of perstent facts at once."""

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -11,7 +11,7 @@ from hamsterlib.backends.sqlalchemy import (AlchemyActivity, AlchemyCategory,
 
 # The reason we see a great deal of count == 0 statements is to make sure that
 # db rollback works as expected. Once we are confident in our sqlalchemy/pytest
-# setup those are not realy needed.
+# setup those are not really needed.
 
 class TestStore(object):
     """Tests to make sure our store/test setup behaves as expected."""
@@ -47,6 +47,19 @@ class TestStore(object):
         assert alchemy_store.session.query(AlchemyCategory).count() == 1
         assert alchemy_category.pk
         assert alchemy_category.name
+
+    def test_get_db_url(self, alchemy_config_parametrized, alchemy_store):
+        """Make sure that db_url composition works as expected."""
+        config, expectation = alchemy_config_parametrized
+        alchemy_store.config = config
+        assert alchemy_store._get_db_url() == expectation
+
+    def test_get_db_url_missing_keys(self, alchemy_config_missing_store_config_parametrized,
+            alchemy_store):
+        """Make sure that db_url composition throws error if key/values are missing in config."""
+        alchemy_store.config = alchemy_config_missing_store_config_parametrized
+        with pytest.raises(ValueError):
+            alchemy_store._get_db_url()
 
 
 class TestCategoryManager():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,8 @@ def base_config(tmpdir):
     return {
         'store': 'sqlalchemy',
         'day_start': datetime.time(hour=5, minute=30, second=0),
-        'db_path': 'sqlite:///:memory:',
+        'db_engine': 'sqlite',
+        'db_path': ':memory:',
         'tmpfile_path': os.path.join(tmpdir.mkdir('tmpfact').strpath, 'hamsterlib.fact'),
         'fact_min_delta': 60,
     }

--- a/tests/hamsterlib/test_storage.py
+++ b/tests/hamsterlib/test_storage.py
@@ -20,9 +20,6 @@ def basestore(base_config):
 
 # Tests
 class TestBaseStore():
-    def test_init(self, base_config):
-        assert BaseStore(base_config).path == base_config['db_path']
-
     def test_cleanup(self, basestore):
         with pytest.raises(NotImplementedError):
             basestore.cleanup()


### PR DESCRIPTION
Instead of passing a ``db_path`` config option and potentially parsing
it for all its semantical content we now accept a veriety of new config
optionss that each backend can retrieve as it sees fit. It is at eachs
backends discretion what keys it requires and to throw errors on invalid
configs. This should allow for better control and more better seperation
of concerns.
As far as our SQLAlchemy backend is conderned we provide a new store
method that will assemble a valid ``db_url`` to be passed on when
creating the engine or raise errors if required key/values are not
present in config.

Closes #107